### PR TITLE
Ihor Kiulian - task: couriers API improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.24</version>

--- a/src/main/java/com/evri/interview/controller/CourierController.java
+++ b/src/main/java/com/evri/interview/controller/CourierController.java
@@ -1,14 +1,15 @@
 package com.evri.interview.controller;
 
 import com.evri.interview.model.Courier;
+import com.evri.interview.model.UpdateCourier;
 import com.evri.interview.service.CourierService;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @AllArgsConstructor
@@ -18,9 +19,18 @@ public class CourierController {
     private CourierService courierService;
 
     @GetMapping("/couriers")
-    public ResponseEntity<List<Courier>> getAllCouriers() {
+    public ResponseEntity<List<Courier>> getAllCouriers(
+            @RequestParam(value = "isActive", required = false) boolean isActive) {
 
-        return ResponseEntity.ok(courierService.getAllCouriers());
+        return ResponseEntity.ok(courierService.getAllCouriers(isActive));
+    }
+
+    @PutMapping("/couriers/{courierId}")
+    public ResponseEntity<Courier> updateCourier(
+            @PathVariable("courierId") Long courierId, @RequestBody @Valid UpdateCourier courier) {
+
+        Optional<Courier> result = courierService.updateCourierById(courierId, courier);
+        return result.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
     }
 
 }

--- a/src/main/java/com/evri/interview/model/UpdateCourier.java
+++ b/src/main/java/com/evri/interview/model/UpdateCourier.java
@@ -1,0 +1,21 @@
+package com.evri.interview.model;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class UpdateCourier {
+
+    @NotBlank(message = "'firstName' cannot be blank")
+    private String firstName;
+
+    @NotBlank(message = "'lastName' cannot be blank")
+    private String lastName;
+
+    @NotNull(message = "'active' status must be provided")
+    private Boolean active;
+}

--- a/src/main/java/com/evri/interview/repository/CourierRepository.java
+++ b/src/main/java/com/evri/interview/repository/CourierRepository.java
@@ -3,7 +3,10 @@ package com.evri.interview.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface CourierRepository extends JpaRepository<CourierEntity, Long> {
 
+    List<CourierEntity> findByActiveTrue();
 }

--- a/src/main/java/com/evri/interview/service/CourierService.java
+++ b/src/main/java/com/evri/interview/service/CourierService.java
@@ -1,11 +1,14 @@
 package com.evri.interview.service;
 
 import com.evri.interview.model.Courier;
+import com.evri.interview.model.UpdateCourier;
+import com.evri.interview.repository.CourierEntity;
 import com.evri.interview.repository.CourierRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -15,10 +18,21 @@ public class CourierService {
     private CourierTransformer courierTransformer;
     private CourierRepository repository;
 
-    public List<Courier> getAllCouriers() {
-        return repository.findAll()
+    public List<Courier> getAllCouriers(boolean isActive) {
+        List<CourierEntity> courierEntities = isActive ? repository.findByActiveTrue() : repository.findAll();
+        return courierEntities
                 .stream()
                 .map(courierTransformer::toCourier)
                 .collect(Collectors.toList());
+    }
+
+    public Optional<Courier> updateCourierById(Long id, UpdateCourier updateCourier) {
+        return repository.findById(id).map(entity -> {
+            entity.setFirstName(updateCourier.getFirstName());
+            entity.setLastName(updateCourier.getLastName());
+            entity.setActive(updateCourier.getActive());
+            CourierEntity updatedEntity = repository.save(entity);
+            return Optional.of(courierTransformer.toCourier(updatedEntity));
+        }).orElse(Optional.empty());
     }
 }

--- a/src/test/java/com/evri/interview/controller/CourierControllerTest.java
+++ b/src/test/java/com/evri/interview/controller/CourierControllerTest.java
@@ -1,0 +1,84 @@
+package com.evri.interview.controller;
+
+import com.evri.interview.model.Courier;
+import com.evri.interview.model.UpdateCourier;
+import com.evri.interview.service.CourierService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class CourierControllerTest {
+
+    @Mock
+    private CourierService courierService;
+
+    @InjectMocks
+    private CourierController courierController;
+
+    @Test
+    @DisplayName("test getting all only active couriers")
+    public void testGetAllCouriers() {
+        boolean isActive = false;
+        List<Courier> couriers = Arrays.asList(mock(Courier.class), mock(Courier.class));
+        when(courierService.getAllCouriers(isActive)).thenReturn(couriers);
+
+        ResponseEntity<List<Courier>> allCouriersResponse = courierController.getAllCouriers(isActive);
+
+        verify(courierService, times(1)).getAllCouriers(isActive);
+        assertEquals(HttpStatus.OK, allCouriersResponse.getStatusCode());
+        assertNotNull(allCouriersResponse.getBody());
+        assertEquals(2, allCouriersResponse.getBody().size());
+    }
+
+    @Test
+    @DisplayName("test updating courier")
+    void testUpdateCourier() {
+        long courierId = 1;
+        Courier expectedCourier = Courier.builder()
+                .id(courierId)
+                .name("Ben Askew")
+                .active(true)
+                .build();
+        UpdateCourier mockedUpdateCourier = mock(UpdateCourier.class);
+        when(courierService.updateCourierById(courierId, mockedUpdateCourier))
+                .thenReturn(Optional.of(expectedCourier));
+
+        ResponseEntity<Courier> courierResponse = courierController.updateCourier(1L, mockedUpdateCourier);
+        assertEquals(HttpStatus.OK, courierResponse.getStatusCode());
+        assertNotNull(courierResponse.getBody());
+        assertEquals(expectedCourier, courierResponse.getBody());
+    }
+
+    @Test
+    @DisplayName("test updating non-existing courier")
+    public void testUpdateCourierNotFound() {
+        UpdateCourier updateCourier = new UpdateCourier("Ben", "1", true);
+        when(courierService.updateCourierById(1L, updateCourier))
+                .thenReturn(Optional.empty());
+
+        ResponseEntity<Courier> updatedCourierResponse = courierController.updateCourier(1L, updateCourier);
+        assertEquals(HttpStatus.NOT_FOUND, updatedCourierResponse.getStatusCode());
+        assertNull(updatedCourierResponse.getBody());
+    }
+
+    private Courier createCourier(long id, String name, boolean isActive) {
+        return Courier.builder()
+                .id(id)
+                .name(name)
+                .active(isActive)
+                .build();
+    }
+}

--- a/src/test/java/com/evri/interview/repository/CourierRepositoryTest.java
+++ b/src/test/java/com/evri/interview/repository/CourierRepositoryTest.java
@@ -1,0 +1,61 @@
+package com.evri.interview.repository;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class CourierRepositoryTest {
+
+    @Autowired
+    private CourierRepository repository;
+
+    @Test
+    @DisplayName("test fetching all couriers")
+    @Sql(statements = {
+            "INSERT INTO couriers (ID, FST_NME, LST_NME, ACTV) VALUES (1, 'Ben', 'Askew', 1)",
+            "INSERT INTO couriers (ID, FST_NME, LST_NME, ACTV) VALUES (2, 'Ihor', 'Kiulian', 0)",
+    })
+    @Sql(statements = "DELETE FROM couriers", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+    void testFindAll() {
+        List<CourierEntity> courierEntities = repository.findAll();
+
+        assertFalse(courierEntities.isEmpty());
+        assertEquals(2, courierEntities.size());
+    }
+
+    @Test
+    @DisplayName("test fetching if db is empty")
+    void testFindAllEmpty() {
+        List<CourierEntity> courierEntities = repository.findAll();
+        assertTrue(courierEntities.isEmpty());
+    }
+
+    @Test
+    @DisplayName("test fetching only active couriers")
+    @Sql(statements = {
+            "INSERT INTO couriers (ID, FST_NME, LST_NME, ACTV) VALUES (1, 'Ben', 'Askew', 1)",
+            "INSERT INTO couriers (ID, FST_NME, LST_NME, ACTV) VALUES (2, 'Ihor', 'Kiulian', 0)",
+            "INSERT INTO couriers (ID, FST_NME, LST_NME, ACTV) VALUES (3, 'Test', 'Courier', 1)",
+    })
+    @Sql(statements = "DELETE FROM couriers", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+    void testFindAllOnlyActive() {
+        List<CourierEntity> courierEntities = repository.findByActiveTrue();
+
+        assertFalse(courierEntities.isEmpty());
+        assertEquals(2, courierEntities.size());
+
+        boolean isAllActive = courierEntities.stream().allMatch(CourierEntity::isActive);
+        assertTrue(isAllActive);
+    }
+}

--- a/src/test/java/com/evri/interview/service/CourierServiceTest.java
+++ b/src/test/java/com/evri/interview/service/CourierServiceTest.java
@@ -1,0 +1,93 @@
+package com.evri.interview.service;
+
+
+import com.evri.interview.model.Courier;
+import com.evri.interview.model.UpdateCourier;
+import com.evri.interview.repository.CourierEntity;
+import com.evri.interview.repository.CourierRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static java.util.Collections.singletonList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class CourierServiceTest {
+
+    @Mock
+    private CourierRepository courierRepository;
+
+    @Mock
+    private CourierTransformer courierTransformer;
+
+    @InjectMocks
+    private CourierService courierService;
+
+    @BeforeEach
+    public void setup() {
+        lenient().when(courierTransformer.toCourier(any(CourierEntity.class))).thenCallRealMethod();
+    }
+
+    @Test
+    @DisplayName("test getting all couriers")
+    public void testGetAllCouriers() {
+        List<CourierEntity> mockedEntities = singletonList(mock(CourierEntity.class));
+        when(courierRepository.findAll()).thenReturn(mockedEntities);
+
+        List<Courier> couriers = courierService.getAllCouriers(false);
+
+        verify(courierRepository).findAll();
+        assertFalse(couriers.isEmpty());
+    }
+
+    @Test
+    @DisplayName("test getting all only active couriers")
+    public void testGetAllCouriersIsActiveTrue() {
+        List<CourierEntity> mockedEntities = singletonList(mock(CourierEntity.class));
+        when(courierRepository.findByActiveTrue()).thenReturn(mockedEntities);
+
+        List<Courier> couriers = courierService.getAllCouriers(true);
+
+        verify(courierRepository).findByActiveTrue();
+        assertFalse(couriers.isEmpty());
+    }
+
+    @Test
+    @DisplayName("test updating courier by id")
+    public void testUpdateCourierById() {
+        CourierEntity mockedEntity = mock(CourierEntity.class);
+        when(courierRepository.findById(anyLong())).thenReturn(Optional.of(mockedEntity));
+        when(courierRepository.save(any(CourierEntity.class))).thenReturn(mockedEntity);
+
+        UpdateCourier updateCourier = new UpdateCourier("Ben", "Askew", true);
+        Optional<Courier> updatedCourier = courierService.updateCourierById(1L,updateCourier);
+
+        verify(courierRepository, times(1)).findById(anyLong());
+        verify(mockedEntity, times(1)).setFirstName(updateCourier.getFirstName());
+        verify(mockedEntity, times(1)).setLastName(updateCourier.getLastName());
+        verify(mockedEntity, times(1)).setActive(updateCourier.getActive());
+        verify(courierRepository, times(1)).save(any(CourierEntity.class));
+        assertTrue(updatedCourier.isPresent());
+    }
+
+    @Test
+    @DisplayName("test updating non-existing courier")
+    public void testUpdateCourierByIdNotFound() {
+        when(courierRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        Optional<Courier> updatedCourier = courierService.updateCourierById(1L, mock(UpdateCourier.class));
+
+        verify(courierRepository, times(1)).findById(anyLong());
+        assertFalse(updatedCourier.isPresent());
+    }
+}

--- a/src/test/java/com/evri/interview/service/CourierTransformerTest.java
+++ b/src/test/java/com/evri/interview/service/CourierTransformerTest.java
@@ -1,0 +1,24 @@
+package com.evri.interview.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import com.evri.interview.model.Courier;
+import com.evri.interview.repository.CourierEntity;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CourierTransformerTest {
+    @Test
+    @DisplayName("test transforming courier entity to courier")
+    void testToCourier() {
+        CourierTransformer transformer = new CourierTransformer();
+        CourierEntity courierEntity = new CourierEntity(1, "Ben", "Askew", true);
+
+        Courier courier = transformer.toCourier(courierEntity);
+
+        assertEquals(1, courier.getId());
+        assertEquals("Ben Askew", courier.getName());
+        assertTrue(courier.isActive());
+    }
+
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:h2:mem:testdb-unittests
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create


### PR DESCRIPTION
Improved couriers API according to the task described in [README.md](https://github.com/EVRI-Engineering/epam-technical-tests/blob/master/README.md)

- implemented **PUT** `/couriers/{courierId}`
- changed **GET** `/couriers` to accept query param `isActive` (defaults to `false`)
**NOTE**: this API might be counter-intuitive because
   - If this parameter is `true`, the endpoint return only couriers whom have an active flag of `true`.
   - If this parameter is `false` (or not passed), the endpoint will return all couriers, not only whom have an active flag of `false`
- increased test coverage